### PR TITLE
Update CLI tool to net6 (LTS) and net7, drop netcore2.1

### DIFF
--- a/src/libman/libman.csproj
+++ b/src/libman/libman.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>Microsoft.Web.LibraryManager.Tools</RootNamespace>
     <PackAsTool>true</PackAsTool>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
@@ -10,9 +10,6 @@
     <PackageId>Microsoft.Web.LibraryManager.Cli</PackageId>
     <Description>Command line tool for Library Manager</Description>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Runtime" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
netcore2.1 is long-since deprecated, so dropping support for it. Instead, adding the current LTS and STS versions.  As a policy going forward, we should maintain these targets according to their lifecycles. The dotnet lifecycle is fairly straight-forward (LTS = 3 years, STS = 1.5 years).

Technically, this is a breaking change, as a machine configured with sdk <net6.0 might not be able to run the tool anymore.
